### PR TITLE
Fixed "Tests' annotations" check name not being able to be set as required in branch protection rules

### DIFF
--- a/docs/src/components/fake-github-parts/PrFooter.tsx
+++ b/docs/src/components/fake-github-parts/PrFooter.tsx
@@ -93,7 +93,7 @@ export const PrFooter = ({ className }: PrFooterProps) => {
                             </CheckItem>
                             <CheckItem last>
                                 <Text ml="2" fontSize="sm">
-                                    coverage / Tests' annotations (🧪
+                                    coverage / Tests annotations (🧪
                                     jest-coverage-report-action) (p...
                                 </Text>
                             </CheckItem>

--- a/src/format/strings.json
+++ b/src/format/strings.json
@@ -40,7 +40,7 @@
     "testsFailSummary": "Failed tests: {{ numFailedTests }}/{{ numTotalTests }}. Failed suites: {{ numFailedTestSuites }}/{{ numTotalTestSuites }}.",
     "testsSuccessSummary": "{{ numPassedTests }} tests passing in {{ numPassedTestSuites }} suite{{ ending }}.",
     "coveredCheckName": "Coverage annotations (🧪 jest-coverage-report-action)",
-    "failedTestsCheckName": "Tests' annotations (🧪 jest-coverage-report-action)",
+    "failedTestsCheckName": "Tests annotations (🧪 jest-coverage-report-action)",
     "coverageTitle": "Coverage report annotations",
     "coverageOk": "✔ Coverage is good {{ coverage }}%",
     "coverageFail": "❌ Coverage is under threshold - {{ coverage }}%, threshold {{ threshold }}%",


### PR DESCRIPTION
Fixes #106.

I took the liberty of updating the fake GitHub component in the docs website, but two of the screenshots might still need to be updated, `/docs/assets/annotation-example.jpg` and `jest-coverage-report-action/docs/assets/failed-test-annotation-example.jpg`.