### PR TITLE
`npx` and `pnpx` are not npm style

### DIFF
--- a/src/utils/getTestCommand.ts
+++ b/src/utils/getTestCommand.ts
@@ -12,9 +12,7 @@ export const getTestCommand = async (
 
     const isNpmStyle =
         command.startsWith('npm') ||
-        command.startsWith('npx') ||
-        command.startsWith('pnpm') ||
-        command.startsWith('pnpx');
+        command.startsWith('pnpm');
 
     // building new command
     const newCommandBuilder: (string | boolean)[] = [


### PR DESCRIPTION
fixes #164 

don't use the `--` convention when running things with a `*px` command. `--` is used with `npm run` scripts to pass arguments to the underlying command. `*px` runs a command directly, so the `--` is interpreted by the interface, which leads to unexpected results.