### PR TITLE
Uniquely identify existing PR comment

### DIFF
--- a/src/constants/getReportTag.ts
+++ b/src/constants/getReportTag.ts
@@ -1,2 +1,29 @@
-export const getReportTag = (dir?: string) =>
-    `<!-- jest coverage report action at ${dir ?? ''} -->`;
+import crypto from 'crypto';
+
+import pick from 'lodash/pick';
+
+import { Options } from '../typings/Options';
+
+const OPTION_NAMES_TO_HASH = [
+    'workingDirectory',
+    'testScript',
+    'coverageFile',
+    'baseCoverageFile',
+] as const;
+
+type OptionsToHash = Pick<Options, typeof OPTION_NAMES_TO_HASH[number]>;
+
+const hashString = (str: string): string => {
+    return crypto.createHash('md5').update(str).digest('hex');
+};
+
+const hashOptions = (options: OptionsToHash) => {
+    const optionsToHash = pick(options, OPTION_NAMES_TO_HASH);
+
+    return hashString(JSON.stringify(optionsToHash));
+};
+
+export const getReportTag = (options: OptionsToHash) => {
+    const optionsHash = hashOptions(options);
+    return `<!-- jest coverage report action for options with hash ${optionsHash} -->`;
+};

--- a/src/constants/getReportTag.ts
+++ b/src/constants/getReportTag.ts
@@ -13,7 +13,7 @@ const OPTION_NAMES_TO_HASH = [
 
 type OptionsToHash = Pick<Options, typeof OPTION_NAMES_TO_HASH[number]>;
 
-const hashString = (str: string): string => {
+const hashString = (str: string) => {
     return crypto.createHash('md5').update(str).digest('hex');
 };
 

--- a/src/report/fetchPreviousReport.ts
+++ b/src/report/fetchPreviousReport.ts
@@ -1,12 +1,13 @@
 import { getOctokit } from '@actions/github';
 
 import { getReportTag } from '../constants/getReportTag';
+import { Options } from '../typings/Options';
 
 export async function fetchPreviousReport(
     octokit: ReturnType<typeof getOctokit>,
     repo: { owner: string; repo: string },
     pr: { number: number },
-    dir?: string
+    options: Options
 ) {
     const commentList = await octokit.paginate(
         'GET /repos/:owner/:repo/issues/:issue_number/comments',
@@ -17,7 +18,7 @@ export async function fetchPreviousReport(
     );
 
     const previousReport = commentList.find((comment) =>
-        (comment as { body: string }).body.startsWith(getReportTag(dir))
+        (comment as { body: string }).body.startsWith(getReportTag(options))
     );
 
     return !previousReport ? null : previousReport;

--- a/src/report/generatePRReport.ts
+++ b/src/report/generatePRReport.ts
@@ -1,15 +1,21 @@
 import { getOctokit } from '@actions/github';
 
 import { fetchPreviousReport } from './fetchPreviousReport';
+import { Options } from '../typings/Options';
 
 export const generatePRReport = async (
     report: string,
-    dir: string | undefined,
+    options: Options,
     repo: { owner: string; repo: string },
     pr: { number: number },
     octokit: ReturnType<typeof getOctokit>
 ) => {
-    const previousReport = await fetchPreviousReport(octokit, repo, pr, dir);
+    const previousReport = await fetchPreviousReport(
+        octokit,
+        repo,
+        pr,
+        options
+    );
 
     if (previousReport) {
         await octokit.issues.updateComment({

--- a/src/run.ts
+++ b/src/run.ts
@@ -103,7 +103,7 @@ export const run = async (
         if (isInPR) {
             await generatePRReport(
                 summaryReport!.text,
-                options.workingDirectory,
+                options,
                 context.repo,
                 context.payload.pull_request!,
                 octokit

--- a/src/run.ts
+++ b/src/run.ts
@@ -89,7 +89,7 @@ export const run = async (
         'generateReportContent',
         dataCollector,
         async () => {
-            return createReport(dataCollector, options.workingDirectory);
+            return createReport(dataCollector, options);
         }
     );
 

--- a/src/stages/createReport.ts
+++ b/src/stages/createReport.ts
@@ -8,6 +8,7 @@ import { getFailureDetails } from '../format/getFailureDetails';
 import { getTestRunSummary } from '../format/summary/getTestRunSummary';
 import template from '../format/template.md';
 import { JsonReport } from '../typings/JsonReport';
+import { Options } from '../typings/Options';
 import { SummaryReport, TestRunReport } from '../typings/Report';
 import { DataCollector } from '../utils/DataCollector';
 import { i18n } from '../utils/i18n';
@@ -20,9 +21,10 @@ export const getSha = () =>
 
 export const createReport = (
     dataCollector: DataCollector<JsonReport>,
-    workingDirectory?: string,
-    customTitle?: string
+    options: Options
 ): SummaryReport => {
+    const { workingDirectory, customTitle } = options;
+
     const { errors, data } = dataCollector.get();
     const [headReport, baseReport] = data;
     const formattedErrors = formatErrors(errors);
@@ -38,7 +40,7 @@ export const createReport = (
         text: insertArgs(template, {
             body: [formattedErrors, coverage, formattedReport].join('\n'),
             dir: workingDirectory || '',
-            tag: getReportTag(workingDirectory),
+            tag: getReportTag(options),
             title: insertArgs(customTitle || i18n('summaryTitle'), {
                 dir: workingDirectory ? `for \`${workingDirectory}\`` : '',
             }),

--- a/tests/constants/getReportTag.test.ts
+++ b/tests/constants/getReportTag.test.ts
@@ -1,12 +1,79 @@
 import { getReportTag } from '../../src/constants/getReportTag';
 
+const REPORT_TAG_REGEX = /<!-- jest coverage report action for options with hash [0-9a-f]{32} -->/;
+
 describe('getReportTag', () => {
-    it('should return report tag', () => {
-        expect(getReportTag('directory')).toBe(
-            '<!-- jest coverage report action at directory -->'
-        );
-        expect(getReportTag(undefined)).toBe(
-            '<!-- jest coverage report action at  -->'
-        );
+    it('should return report tag for full options', () => {
+        const options = {
+            workingDirectory: 'directory',
+            testScript: 'script',
+            coverageFile: 'coverage',
+            baseCoverageFile: 'baseCoverage',
+        };
+
+        const reportTag = getReportTag(options);
+
+        expect(reportTag).toMatch(REPORT_TAG_REGEX);
+    });
+
+    it('should return report tag for partial options', () => {
+        const options = {
+            testScript: 'script',
+        };
+
+        const reportTag = getReportTag(options);
+
+        expect(reportTag).toMatch(REPORT_TAG_REGEX);
+    });
+
+    it('should return different tags for different options', () => {
+        const options = {
+            workingDirectory: 'directory',
+            testScript: 'script',
+            coverageFile: 'coverage',
+            baseCoverageFile: 'baseCoverage',
+        };
+
+        const reportTag = getReportTag(options);
+
+        [
+            'workingDirectory',
+            'testScript',
+            'coverageFile',
+            'baseCoverageFile',
+        ].forEach((option) => {
+            const changedOptions = { ...options, [option]: 'changed option' };
+
+            const changedReportTag = getReportTag(changedOptions);
+
+            expect(changedReportTag).not.toEqual(reportTag);
+        });
+    });
+
+    it('should return same tag if only arbitrary options change', () => {
+        const options = {
+            workingDirectory: 'directory',
+            testScript: 'script',
+            coverageFile: 'coverage',
+            baseCoverageFile: 'baseCoverage',
+        };
+
+        const reportTag = getReportTag(options);
+
+        [
+            'token',
+            'iconType',
+            'annotations',
+            'threshold',
+            'packageManager',
+            'skipStep',
+            'customTitle',
+        ].forEach((option) => {
+            const changedOptions = { ...options, [option]: 'changed option' };
+
+            const changedReportTag = getReportTag(changedOptions);
+
+            expect(changedReportTag).toEqual(reportTag);
+        });
     });
 });

--- a/tests/report/fetchPreviousReport.test.ts
+++ b/tests/report/fetchPreviousReport.test.ts
@@ -2,6 +2,16 @@ import type { getOctokit } from '@actions/github';
 
 import { getReportTag } from '../../src/constants/getReportTag';
 import { fetchPreviousReport } from '../../src/report/fetchPreviousReport';
+import { Options } from '../../src/typings/Options';
+
+const DEFAULT_OPTIONS: Options = {
+    token: '',
+    testScript: '',
+    iconType: 'emoji',
+    annotations: 'all',
+    packageManager: 'npm',
+    skipStep: 'all',
+};
 
 describe('fetchPreviousReport', () => {
     it('should find previous report', async () => {
@@ -15,7 +25,9 @@ describe('fetchPreviousReport', () => {
                 body: 'Another comment',
             },
             {
-                body: `${getReportTag()}\n This is jest-coverage-report-action report`,
+                body: `${getReportTag(
+                    DEFAULT_OPTIONS
+                )}\n This is jest-coverage-report-action report`,
             },
             {
                 body: 'One more comment',
@@ -33,10 +45,13 @@ describe('fetchPreviousReport', () => {
                 },
                 {
                     number: 5,
-                }
+                },
+                DEFAULT_OPTIONS
             )
         ).resolves.toStrictEqual({
-            body: `${getReportTag()}\n This is jest-coverage-report-action report`,
+            body: `${getReportTag(
+                DEFAULT_OPTIONS
+            )}\n This is jest-coverage-report-action report`,
         });
 
         expect(paginate).toBeCalledWith(
@@ -58,7 +73,7 @@ describe('fetchPreviousReport', () => {
             },
             {
                 body: `${getReportTag(
-                    'folder1'
+                    DEFAULT_OPTIONS
                 )}\n This is jest-coverage-report-action report`,
             },
             {
@@ -66,7 +81,7 @@ describe('fetchPreviousReport', () => {
             },
             {
                 body: `${getReportTag(
-                    'folder2'
+                    DEFAULT_OPTIONS
                 )}\n This is jest-coverage-report-action report`,
             },
             {
@@ -86,11 +101,11 @@ describe('fetchPreviousReport', () => {
                 {
                     number: 5,
                 },
-                'folder2'
+                DEFAULT_OPTIONS
             )
         ).resolves.toStrictEqual({
             body: `${getReportTag(
-                'folder2'
+                DEFAULT_OPTIONS
             )}\n This is jest-coverage-report-action report`,
         });
     });
@@ -122,7 +137,7 @@ describe('fetchPreviousReport', () => {
                 {
                     number: 5,
                 },
-                'folder2'
+                DEFAULT_OPTIONS
             )
         ).resolves.toStrictEqual(null);
     });

--- a/tests/report/generatePRReport.test.ts
+++ b/tests/report/generatePRReport.test.ts
@@ -2,6 +2,16 @@ import type { getOctokit } from '@actions/github';
 
 import { getReportTag } from '../../src/constants/getReportTag';
 import { generatePRReport } from '../../src/report/generatePRReport';
+import { Options } from '../../src/typings/Options';
+
+const DEFAULT_OPTIONS: Options = {
+    token: '',
+    testScript: '',
+    iconType: 'emoji',
+    annotations: 'all',
+    packageManager: 'npm',
+    skipStep: 'all',
+};
 
 describe('generatePRReport', () => {
     it('should generate new PR report', async () => {
@@ -11,7 +21,7 @@ describe('generatePRReport', () => {
 
         await generatePRReport(
             'Report body',
-            undefined,
+            DEFAULT_OPTIONS,
             {
                 owner: 'bot',
                 repo: 'test-repository',
@@ -41,7 +51,7 @@ describe('generatePRReport', () => {
     it('should update old report', async () => {
         const paginate = jest.fn(() => [
             {
-                body: `${getReportTag()}`,
+                body: `${getReportTag(DEFAULT_OPTIONS)}`,
                 id: 15,
             },
         ]);
@@ -50,7 +60,7 @@ describe('generatePRReport', () => {
 
         await generatePRReport(
             'Report body',
-            undefined,
+            DEFAULT_OPTIONS,
             {
                 owner: 'bot',
                 repo: 'test-repository',

--- a/tests/stages/__snapshots__/createReport.test.ts.snap
+++ b/tests/stages/__snapshots__/createReport.test.ts.snap
@@ -7,7 +7,7 @@ Object {
     "summary": "Failed tests: 0/12. Failed suites: 0/5.",
     "title": "Test suite run failed",
   },
-  "text": "<!-- jest coverage report action at  -->
+  "text": "<!-- jest coverage report action for options with hash 07a2060717d2c01f3ad9c6a8cfe3ca1b -->
 
 ## Coverage report 
 
@@ -35,9 +35,9 @@ Object {
     "summary": "12 tests passing in 5 suites.",
     "title": "Test suite run success",
   },
-  "text": "<!-- jest coverage report action at  -->
+  "text": "<!-- jest coverage report action for options with hash 8f0735414be39738f79dc9c8549004e2 -->
 
-## Coverage report 
+## Coverage report for \`custom directory\`
 
 
 | <div title=\\"Status of coverage: 🟢 - ok, 🟡 - slightly more than threshold, 🔴 - under the threshold\\">St.<sup>:grey_question:</sup></div> | Category   | Percentage | Covered / Total |
@@ -63,9 +63,9 @@ Object {
     "summary": "12 tests passing in 5 suites.",
     "title": "Test suite run success",
   },
-  "text": "<!-- jest coverage report action at custom directory -->
+  "text": "<!-- jest coverage report action for options with hash 07a2060717d2c01f3ad9c6a8cfe3ca1b -->
 
-## Coverage report for \`custom directory\`
+## Coverage report 
 
 
 | <div title=\\"Status of coverage: 🟢 - ok, 🟡 - slightly more than threshold, 🔴 - under the threshold\\">St.<sup>:grey_question:</sup></div> | Category   | Percentage | Covered / Total |
@@ -91,7 +91,7 @@ Object {
     "summary": "12 tests passing in 5 suites.",
     "title": "Test suite run success",
   },
-  "text": "<!-- jest coverage report action at directory -->
+  "text": "<!-- jest coverage report action for options with hash 786d68e69563a4350059172c9bcae6ec -->
 
 ## Custom title with directory - for \`directory\`
 

--- a/tests/stages/createReport.test.ts
+++ b/tests/stages/createReport.test.ts
@@ -2,10 +2,20 @@ import * as all from '@actions/github';
 
 import { createReport, getSha } from '../../src/stages/createReport';
 import { JsonReport } from '../../src/typings/JsonReport';
+import { Options } from '../../src/typings/Options';
 import { createDataCollector } from '../../src/utils/DataCollector';
 import report from '../mock-data/jsonReport.json';
 
 const { mockContext, clearContextMock } = all as any;
+
+const DEFAULT_OPTIONS: Options = {
+    token: '',
+    testScript: '',
+    iconType: 'emoji',
+    annotations: 'all',
+    packageManager: 'npm',
+    skipStep: 'all',
+};
 
 describe('createReport', () => {
     it('should match snapshots', async () => {
@@ -13,17 +23,22 @@ describe('createReport', () => {
         dataCollector.add(report);
 
         mockContext({ payload: { after: '123456' } });
-        expect(await createReport(dataCollector)).toMatchSnapshot();
         expect(
-            await createReport(dataCollector, 'custom directory')
+            await createReport(dataCollector, {
+                ...DEFAULT_OPTIONS,
+                workingDirectory: 'custom directory',
+            })
+        ).toMatchSnapshot();
+        expect(
+            await createReport(dataCollector, DEFAULT_OPTIONS)
         ).toMatchSnapshot();
 
         expect(
-            await createReport(
-                dataCollector,
-                'directory',
-                'Custom title with directory - {{ dir }}'
-            )
+            await createReport(dataCollector, {
+                ...DEFAULT_OPTIONS,
+                workingDirectory: 'directory',
+                customTitle: 'Custom title with directory - {{ dir }}',
+            })
         ).toMatchSnapshot();
 
         clearContextMock();
@@ -35,7 +50,9 @@ describe('createReport', () => {
 
         mockContext({ payload: { after: '123456' } });
 
-        expect(await createReport(dataCollector)).toMatchSnapshot();
+        expect(
+            await createReport(dataCollector, DEFAULT_OPTIONS)
+        ).toMatchSnapshot();
 
         clearContextMock();
     });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

#### Summary
The PR makes the action include fields `testScript`, coverageFile`, and `baseCoverageFile` to the report tag along with the `workingDirectory` field. The action will identify an existing PR comment more precisely using these fields.

I didn't include all the options into the report tag because this might have caused the action not to identify existing comments because some of the "cosmetic" settings were changed. For example, the `custom-title` option may change during a sequence of action invocations. I can imagine a use-case when a user adds the invocation counter or commit ID to the `custom-title`. The same considerations apply to other options that were not included in the report tag.

**Note:** this PR also fixes a small bug with the `customTitle` it basically was not propagated to the `createReport` function in `run.ts`. Now it is passed to the function along with other `options`.

This PR fixes #146 

cc @ArtiomTr 