### PR TITLE
Use latest version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v1
-            - uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
+            - uses: artiomtr/jest-coverage-report-action@v2.0-rc.5
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   #   threshold: 80 # optional parameter


### PR DESCRIPTION
This PR fixes the documentation using an old version. I ran into problems with this because I was trying to use new inputs that were not part of the older referenced version.