### PR TITLE
Log errors and messages in realtime

### DIFF
--- a/__mocks__/@actions/core/index.ts
+++ b/__mocks__/@actions/core/index.ts
@@ -12,4 +12,6 @@ export const clearInputMock = () => {
     });
 };
 
+export const error = jest.fn();
+export const info = jest.fn();
 export const setFailed = jest.fn();

--- a/src/utils/DataCollector.ts
+++ b/src/utils/DataCollector.ts
@@ -1,3 +1,5 @@
+import * as core from '@actions/core';
+
 export const createDataCollector = <T>(): DataCollector<T> => {
     const errors: Array<Error> = [];
     const collectedData: Array<T> = [];
@@ -5,6 +7,7 @@ export const createDataCollector = <T>(): DataCollector<T> => {
 
     const error = (error: Error) => {
         errors.push(error);
+        core.error(error);
     };
 
     const add = (data: T) => {
@@ -13,6 +16,7 @@ export const createDataCollector = <T>(): DataCollector<T> => {
 
     const info = (message: string) => {
         messages.push(message);
+        core.info(message);
     };
 
     const get = () => ({

--- a/tests/utils/DataCollector.test.ts
+++ b/tests/utils/DataCollector.test.ts
@@ -1,14 +1,24 @@
+import * as core from '@actions/core';
+
 import { ActionError } from '../../src/typings/ActionError';
 import { FailReason } from '../../src/typings/Report';
 import { createDataCollector } from '../../src/utils/DataCollector';
 
 describe('DataCollector', () => {
+    beforeEach(() => {
+        (core.error as jest.Mock).mockClear();
+        (core.info as jest.Mock).mockClear();
+    });
+
     it('should collect data', () => {
         const dataCollector = createDataCollector();
 
         dataCollector.add('hello');
         dataCollector.add('world');
         dataCollector.add('this');
+
+        expect(core.error).not.toHaveBeenCalled();
+        expect(core.info).not.toHaveBeenCalled();
 
         expect(dataCollector.get().data).toStrictEqual([
             'hello',
@@ -28,6 +38,9 @@ describe('DataCollector', () => {
             })
         );
 
+        expect(core.error).toHaveBeenCalledTimes(3);
+        expect(core.info).not.toHaveBeenCalled();
+
         expect(dataCollector.get().errors).toStrictEqual([
             new ActionError(FailReason.TESTS_FAILED),
             new Error('world'),
@@ -43,6 +56,9 @@ describe('DataCollector', () => {
         dataCollector.info('hello');
         dataCollector.info('world');
         dataCollector.info('this');
+
+        expect(core.error).not.toHaveBeenCalled();
+        expect(core.info).toHaveBeenCalledTimes(3);
 
         expect(dataCollector.get().messages).toStrictEqual([
             'hello',


### PR DESCRIPTION
This change reports errors and messages to the action's log as it's collected, both to make sure no error or message is lost and to correctly interleave errors and messages with any child command/process output.

Fixes #178

The screenshot below demonstrates the resulting log (with this change) for the same repo of #178.

![image](https://user-images.githubusercontent.com/5903869/136961840-eb39919e-067a-4d97-9273-024bb5f5e584.png)
