### PR TITLE
Don't add a double hyphen to custom test scripts when a double hyphen already exists in the test script

### DIFF
--- a/src/utils/getTestCommand.ts
+++ b/src/utils/getTestCommand.ts
@@ -12,13 +12,13 @@ export const getTestCommand = async (
 
     const isNpmStyle = command.startsWith('npm') || command.startsWith('pnpm');
 
-    const hasDoubleHyhen = command.includes( ' -- ' );
+    const hasDoubleHyhen = command.includes(' -- ');
 
     // building new command
     const newCommandBuilder: (string | boolean)[] = [
         command,
         // add two hypens if it is npm or pnpm package managers and two hyphens don't already exist
-        isNpmStyle && ! hasDoubleHyhen && '--',
+        isNpmStyle && !hasDoubleHyhen && '--',
         // argument which indicates that jest runs in CI environment
         '--ci',
         // telling jest that output should be in json format

--- a/tests/utils/getTestCommand.test.ts
+++ b/tests/utils/getTestCommand.test.ts
@@ -21,32 +21,47 @@ describe('getTestCommand', () => {
 
     it('should add double hyphens for npm and pnpm', async () => {
         expect(
-            await getTestCommand('npm run test:coverage', 'report.json', undefined)
+            await getTestCommand(
+                'npm run test:coverage',
+                'report.json',
+                undefined
+            )
         ).toBe(
             'npm run test:coverage -- --ci --json --coverage --testLocationInResults --outputFile="report.json"'
         );
 
         expect(
-            await getTestCommand('pnpm run test:coverage', 'report.json', undefined)
+            await getTestCommand(
+                'pnpm run test:coverage',
+                'report.json',
+                undefined
+            )
         ).toBe(
             'pnpm run test:coverage -- --ci --json --coverage --testLocationInResults --outputFile="report.json"'
         );
-    } );
+    });
 
     it('should not add two sets of double hyphens for npm and pnpm', async () => {
         expect(
-            await getTestCommand('npm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary"', 'report.json', undefined)
+            await getTestCommand(
+                'npm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary"',
+                'report.json',
+                undefined
+            )
         ).toBe(
             'npm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary" --ci --json --coverage --testLocationInResults --outputFile="report.json"'
         );
 
         expect(
-            await getTestCommand('pnpm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary"', 'report.json', undefined)
+            await getTestCommand(
+                'pnpm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary"',
+                'report.json',
+                undefined
+            )
         ).toBe(
             'pnpm run test:coverage -- --coverageReporters="text" --coverageReporters="text-summary" --ci --json --coverage --testLocationInResults --outputFile="report.json"'
         );
-    } );
-
+    });
 
     it('should keep command', async () => {
         expect(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR fixes #179
