### PR TITLE
Fix action name and version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v1
-            - uses: artiomtr/jest-coverage-report-action@v2.0-rc.5
+            - uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   #   threshold: 80 # optional parameter


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

I've tried `artiomtr/jest-coverage-report-action` on READM, but it didn't work. Instead, `ArtiomTr/jest-coverage-report-action` worked.

Also, this change updates to the latest tag.

No issue with this PR since this change is just a small documentation fix.