### PR TITLE
fix: rmdir is being deprecated

### DIFF
--- a/__mocks__/fs-extra/index.ts
+++ b/__mocks__/fs-extra/index.ts
@@ -1,3 +1,3 @@
 export const readFile = jest.fn();
 
-export const rmdir = jest.fn();
+export const rm = jest.fn();

--- a/src/stages/installDependencies.ts
+++ b/src/stages/installDependencies.ts
@@ -1,5 +1,5 @@
 import { exec } from '@actions/exec';
-import { rmdir } from 'fs-extra';
+import { rm } from 'fs-extra';
 
 import { PackageManagerType } from '../typings/Options';
 import { joinPaths } from '../utils/joinPaths';
@@ -9,7 +9,7 @@ export const installDependencies = async (
     workingDirectory?: string
 ) => {
     // NOTE: The `npm ci` command is not used. Because if your version of npm is old, the generated `package-lock.json` will also be old, and the latest version of `npm ci` will fail.
-    await rmdir(joinPaths(workingDirectory, 'node_modules'), {
+    await rm(joinPaths(workingDirectory, 'node_modules'), {
         recursive: true,
     });
 

--- a/src/stages/installDependencies.ts
+++ b/src/stages/installDependencies.ts
@@ -11,6 +11,7 @@ export const installDependencies = async (
     // NOTE: The `npm ci` command is not used. Because if your version of npm is old, the generated `package-lock.json` will also be old, and the latest version of `npm ci` will fail.
     await rm(joinPaths(workingDirectory, 'node_modules'), {
         recursive: true,
+        force: true,
     });
 
     await exec(`${packageManager} install`, undefined, {

--- a/tests/stages/getCoverage.test.ts
+++ b/tests/stages/getCoverage.test.ts
@@ -1,5 +1,5 @@
 import { exec } from '@actions/exec';
-import { readFile, rmdir } from 'fs-extra';
+import { readFile, rm } from 'fs-extra';
 
 import { getCoverage } from '../../src/stages/getCoverage';
 import { ActionError } from '../../src/typings/ActionError';
@@ -19,7 +19,7 @@ const defaultOptions: Options = {
 
 const clearMocks = () => {
     (exec as jest.Mock<any, any>).mockClear();
-    (rmdir as jest.Mock<any, any>).mockClear();
+    (rm as jest.Mock<any, any>).mockClear();
     (readFile as jest.Mock<any, any>).mockClear();
 };
 
@@ -38,7 +38,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).toBeCalledWith('node_modules', { recursive: true });
         expect(exec).toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -66,7 +66,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('testDir/node_modules', {
+        expect(rm).toBeCalledWith('testDir/node_modules', {
             recursive: true,
         });
         expect(exec).toBeCalledWith('npm install', undefined, {
@@ -115,7 +115,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).not.toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).not.toBeCalledWith('node_modules', { recursive: true });
         expect(exec).not.toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -143,7 +143,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).not.toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).not.toBeCalledWith('node_modules', { recursive: true });
         expect(exec).not.toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -171,7 +171,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).toBeCalledWith('node_modules', { recursive: true });
         expect(exec).toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -199,7 +199,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).toBeCalledWith('node_modules', { recursive: true });
         expect(exec).toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -230,7 +230,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).toBeCalledWith('node_modules', { recursive: true });
         expect(exec).toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -263,7 +263,7 @@ describe('getCoverage', () => {
             undefined
         );
 
-        expect(rmdir).toBeCalledWith('node_modules', { recursive: true });
+        expect(rm).toBeCalledWith('node_modules', { recursive: true });
         expect(exec).toBeCalledWith('npm install', undefined, {
             cwd: undefined,
         });
@@ -308,7 +308,7 @@ describe('getCoverage', () => {
             'custom filepath'
         );
 
-        expect(rmdir).not.toBeCalled();
+        expect(rm).not.toBeCalled();
         expect(exec).not.toBeCalled();
         expect(readFile).toBeCalledWith('custom filepath');
         expect(readFile).toBeCalledTimes(1);
@@ -329,7 +329,7 @@ describe('getCoverage', () => {
             new ActionError(FailReason.FAILED_GETTING_COVERAGE)
         );
 
-        expect(rmdir).not.toBeCalled();
+        expect(rm).not.toBeCalled();
         expect(exec).not.toBeCalled();
         expect(readFile).toBeCalledWith('custom filepath');
         expect(readFile).toBeCalledTimes(1);

--- a/tests/stages/installDependencies.test.ts
+++ b/tests/stages/installDependencies.test.ts
@@ -1,11 +1,11 @@
 import { exec } from '@actions/exec';
-import { rmdir } from 'fs-extra';
+import { rm } from 'fs-extra';
 
 import { installDependencies } from '../../src/stages/installDependencies';
 
 const clearMocks = () => {
     (exec as jest.Mock<any, any>).mockClear();
-    (rmdir as jest.Mock<any, any>).mockClear();
+    (rm as jest.Mock<any, any>).mockClear();
 };
 
 beforeEach(clearMocks);
@@ -14,7 +14,7 @@ describe('installDependencies', () => {
     it('should remove "node_modules" directory', async () => {
         await installDependencies();
 
-        expect(rmdir).toBeCalledWith('node_modules', {
+        expect(rm).toBeCalledWith('node_modules', {
             recursive: true,
         });
     });
@@ -22,7 +22,7 @@ describe('installDependencies', () => {
     it('should remove "node_modules" directory, which is under specified working directory', async () => {
         await installDependencies(undefined, 'workingDir');
 
-        expect(rmdir).toBeCalledWith('workingDir/node_modules', {
+        expect(rm).toBeCalledWith('workingDir/node_modules', {
             recursive: true,
         });
     });
@@ -61,7 +61,7 @@ describe('installDependencies', () => {
 
     it("shouldn't install dependencies, if node_modules directory deletion failed", async () => {
         try {
-            (rmdir as jest.Mock<any, any>).mockImplementationOnce(() => {
+            (rm as jest.Mock<any, any>).mockImplementationOnce(() => {
                 throw 0;
             });
             await installDependencies();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR fixes #
Since Yesterday Installing dependencies are failing, there is a warning about a deprecation happening 
<img width="787" alt="Captura de Pantalla 2021-12-03 a la(s) 10 03 42 a m" src="https://user-images.githubusercontent.com/4117152/144624574-db90b9b3-a968-4d5f-82ad-d20e728d0735.png">

