### PR TITLE
Only skip base coverage collection if using same coverage file between branches

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -81,7 +81,7 @@ export const run = async (
         'baseCoverage',
         dataCollector,
         async (skip) => {
-            if (!isSwitched) {
+            if (!isSwitched && options.coverageFile === options.baseCoverageFile) {
                 skip();
             }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -81,7 +81,7 @@ export const run = async (
         'baseCoverage',
         dataCollector,
         async (skip) => {
-            if (!isSwitched && options.coverageFile === options.baseCoverageFile) {
+            if (!isSwitched && options.baseCoverageFile === undefined) {
                 skip();
             }
 


### PR DESCRIPTION
This PR fixes #214 

The logic behind this change is that if a user has specified separate files for current and base coverage files then they are being explicit in that they don't need to switch between branches to compare the diff of a single file and so we should not need to skip the base coverage collection.