### PR TITLE
recognize `pnpm` as a package manager, add `pnpm` tests, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,22 @@ with:
     test-script: npm run test:coverage
 ```
 
-## Usage with `yarn`
+## Usage with `yarn` or `pnpm`
 
-By default, this action will install your dependencies using `npm`. If you are using `yarn`, you can specify it in the `package-manager` option:
+By default, this action will install your dependencies using `npm`. If you are using `yarn` or `pnpm`, you can specify it in the `package-manager` option:
 
 ```yml
 with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     package-manager: yarn
+```
+
+or
+
+```yml
+with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    package-manager: pnpm
 ```
 
 ## Use existing test report(s)

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
         default: all
     package-manager:
         required: false
-        description: 'Which package manager to use; can be either `npm` or `yarn`'
+        description: 'Which package manager to use; can be `npm`, `yarn`, or `pnpm`'
         default: 'npm'
     skip-step:
         required: false

--- a/docs/src/pages/configuration.md
+++ b/docs/src/pages/configuration.md
@@ -98,12 +98,20 @@ If you want to enable only specific annotations, you can specify following choic
 
 ### package-manager
 
-By default, action uses [npm](https://github.com/npm/cli#readme) package manager. But, if you want to use [yarn](https://github.com/yarnpkg/berry#readme), simply set `package-manager: yarn` option:
+By default, action uses [npm](https://github.com/npm/cli#readme) package manager. But, if you want to use [yarn](https://github.com/yarnpkg/berry#readme) or [pnpm](https://pnpm.io/), simply set `package-manager`option to `yarn` or `pnpm`:
 
 ```yaml
 with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     package-manager: yarn
+```
+
+or
+
+```yaml
+with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    package-manager: pnpm
 ```
 
 ### skip-step

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -27,6 +27,13 @@ Or via yarn:
 yarn jest
 ```
 
+Or via pnpm (pnpx):
+
+```bash
+
+pnpx jest
+```
+
 <!-- TODO: replace link -->
 
 If this command is not working for you, see [how to setup custom testing script](https://github.com/ArtiomTr/jest-coverage-report-action#customizing-test-script).

--- a/src/typings/Options.ts
+++ b/src/typings/Options.ts
@@ -6,7 +6,7 @@ import { icons } from '../format/strings.json';
 export type IconType = keyof typeof icons;
 
 export type AnnotationType = 'all' | 'none' | 'coverage' | 'failed-tests';
-export type PackageManagerType = 'npm' | 'yarn';
+export type PackageManagerType = 'npm' | 'yarn' | 'pnpm';
 export type SkipStepType = 'all' | 'none' | 'install';
 
 export type Options = {
@@ -30,7 +30,11 @@ const validAnnotationOptions: Array<AnnotationType> = [
     'failed-tests',
 ];
 
-const packageManagerOptions: Array<PackageManagerType> = ['npm', 'yarn'];
+const packageManagerOptions: Array<PackageManagerType> = [
+    'npm',
+    'yarn',
+    'pnpm',
+];
 
 const validIconOptions = Object.keys(icons);
 

--- a/tests/stages/getCoverage.test.ts
+++ b/tests/stages/getCoverage.test.ts
@@ -93,7 +93,7 @@ describe('getCoverage', () => {
 
         (readFile as jest.Mock<any, any>).mockImplementationOnce(() => '{}');
 
-        const jsonReport = await getCoverage(
+        const jsonReportYarn = await getCoverage(
             dataCollector,
             { ...defaultOptions, packageManager: 'yarn' },
             false,
@@ -104,7 +104,22 @@ describe('getCoverage', () => {
             cwd: undefined,
         });
 
-        expect(jsonReport).toStrictEqual({});
+        expect(jsonReportYarn).toStrictEqual({});
+
+        (readFile as jest.Mock<any, any>).mockImplementationOnce(() => '{}');
+
+        const jsonReportPnpm = await getCoverage(
+            dataCollector,
+            { ...defaultOptions, packageManager: 'pnpm' },
+            false,
+            undefined
+        );
+
+        expect(exec).toBeCalledWith('pnpm install', undefined, {
+            cwd: undefined,
+        });
+
+        expect(jsonReportPnpm).toStrictEqual({});
     });
 
     it('should skip installation step', async () => {

--- a/tests/stages/installDependencies.test.ts
+++ b/tests/stages/installDependencies.test.ts
@@ -52,6 +52,14 @@ describe('installDependencies', () => {
         });
     });
 
+    it('should install dependencies using pnpm', async () => {
+        await installDependencies('pnpm');
+
+        expect(exec).toBeCalledWith('pnpm install', undefined, {
+            cwd: undefined,
+        });
+    });
+
     it('should install dependencies under specified working directory', async () => {
         await installDependencies(undefined, 'workingDir');
 

--- a/tests/utils/isOldScript.test.ts
+++ b/tests/utils/isOldScript.test.ts
@@ -61,6 +61,7 @@ describe('isOldScript', () => {
         );
 
         expect(await isOldScript('npm test', undefined)).toBe(true);
+        expect(await isOldScript('pnpm test', undefined)).toBe(true);
         expect(await isOldScript('yarn test', undefined)).toBe(true);
         expect(await isOldScript('yarn run test', undefined)).toBe(true);
         expect(await isOldScript('yarn run test:coverage', undefined)).toBe(
@@ -73,6 +74,13 @@ describe('isOldScript', () => {
         expect(await isOldScript('npm run test -- --coverage', undefined)).toBe(
             true
         );
+        expect(await isOldScript('pnpm run test', undefined)).toBe(true);
+        expect(await isOldScript('pnpm run test:coverage', undefined)).toBe(
+            false
+        );
+        expect(
+            await isOldScript('pnpm run test -- --coverage', undefined)
+        ).toBe(true);
 
         (readFile as jest.Mock<any, any>).mockClear();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR:
- recognize `pnpm` as a `PackageManagerType` (`src/typings/Options.ts`) because `packageScriptRegex` (`src/utils/isOldScript.ts`) recognized it.
- add some missing tests for `pnpm`, make sure that all `yarn` tests have corresponding `pnpm` tests.
- update docs, add `pnpm` examples.

I don't know if this action should support `pnpm`, but `packageScriptRegex` in `src/utils/isOldScript.ts` seems to do so.