### PR TITLE
skip switching branch when not necessary

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -67,7 +67,11 @@ export const run = async (
         async (skip) => {
             const baseBranch = context.payload.pull_request?.base.ref;
 
-            if (!isInPR || !baseBranch) {
+            // no need to switch branch when:
+            // - this is not a PR
+            // - this is the PR base branch
+            // - a baseCoverageFile is provided
+            if (!isInPR || !baseBranch || !!options.baseCoverageFile) {
                 skip();
             }
 
@@ -81,7 +85,7 @@ export const run = async (
         'baseCoverage',
         dataCollector,
         async (skip) => {
-            if (!isSwitched && options.baseCoverageFile === undefined) {
+            if (!isSwitched) {
                 skip();
             }
 


### PR DESCRIPTION
This PR fixes #236

The idea is to skip switching to the base branch when the user already provided a coverage report via the `base-coverage-file` option.

This PR improves on the work done in #215 by also skipping the `switchToBase` step.
