### PR TITLE
Collect base coverage when switching is skipped

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -85,7 +85,7 @@ export const run = async (
         'baseCoverage',
         dataCollector,
         async (skip) => {
-            if (!isSwitched) {
+            if (!isSwitched && !options.baseCoverageFile) {
                 skip();
             }
 


### PR DESCRIPTION
Keep collection base coverage data even if switching is skipped due to an existing base coverage file.

With #237 switching branches is skipped when a file for the base coverage is provided. But the coverage data of the base report is not collected when the branches are not switched.
