### PR TITLE
docs: remove slashes from secret interpolation

### DIFF
--- a/docs/src/pages/configuration.md
+++ b/docs/src/pages/configuration.md
@@ -17,7 +17,7 @@ GitHub token. Required parameter. By default, you can use standard GitHub-provid
 ```yaml
 - uses: artiomtr/jest-coverage-report-action@v2
     with:
-        github-token: \${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## threshold


### PR DESCRIPTION
I've lost some minutes because I used slashes, based on the docs, the slashes don't need to interpolate secrets.