### PR TITLE
Switches back to previous branch.

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -10,7 +10,7 @@ import { generatePRReport } from './report/generatePRReport';
 import { checkThreshold } from './stages/checkThreshold';
 import { createReport } from './stages/createReport';
 import { getCoverage } from './stages/getCoverage';
-import { switchBranch } from './stages/switchBranch';
+import { switchBack, switchBranch } from './stages/switchBranch';
 import { JsonReport } from './typings/JsonReport';
 import { getOptions } from './typings/Options';
 import { createDataCollector, DataCollector } from './utils/DataCollector';
@@ -103,7 +103,7 @@ export const run = async (
             skip();
         }
 
-        await switchBranch(context.payload.pull_request!.head.ref);
+        await switchBack();
     });
 
     if (baseCoverage) {

--- a/src/stages/switchBranch.ts
+++ b/src/stages/switchBranch.ts
@@ -9,3 +9,11 @@ export const switchBranch = async (branch: string) => {
 
     await exec(`git checkout -f ${branch}`);
 };
+
+export const switchBack = async () => {
+    try {
+        await exec(`git checkout -`);
+    } catch (err) {
+        console.warn('Error checking to branches', err);
+    }
+};

--- a/tests/stages/switchBranch.test.ts
+++ b/tests/stages/switchBranch.test.ts
@@ -1,6 +1,6 @@
 import { exec } from '@actions/exec';
 
-import { switchBranch } from '../../src/stages/switchBranch';
+import { switchBack, switchBranch } from '../../src/stages/switchBranch';
 
 const clearMocks = () => {
     (exec as jest.Mock<any, any>).mockClear();
@@ -24,5 +24,13 @@ describe('switchBranch', () => {
         await switchBranch('Test-branch');
 
         expect(exec).toBeCalledWith('git checkout -f Test-branch');
+    });
+});
+
+describe('switchBack', () => {
+    it('should switch to previous branch', async () => {
+        await switchBack();
+
+        expect(exec).toBeCalledWith('git checkout -');
     });
 });


### PR DESCRIPTION
This solves the issue to checkout from different origins, e.g., in
pull requests from forks. 
To test this, open a pull request from a fork and no failures must be seen. 

This PR fixes #256
