### PR TITLE
add github-token to minimal config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ jobs:
             - uses: ArtiomTr/jest-coverage-report-action@v2
               id: coverage
               with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   output: report-markdown
             - uses: marocchino/sticky-pull-request-comment@v2
               with:


### PR DESCRIPTION
This PR adds the [required github-token](https://github.com/ArtiomTr/jest-coverage-report-action/blob/main/action.yml#L8-L9) to the minimal config example, making it copy-pastable