### PR TITLE
Load jest config from package.json if no dedicated config file found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,9 +1155,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
             "dev": true
         },
         "acorn-globals": {
@@ -1182,7 +1182,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -1367,6 +1368,12 @@
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
             "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
+        "binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1429,19 +1436,22 @@
             "dev": true
         },
         "c12": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/c12/-/c12-0.2.13.tgz",
-            "integrity": "sha512-wJL0/knDbqM/3moLb+8Xd+w3JdkggkIIhiNBkxZ1mWlskKC/vajb85wM3UPg/D9nK6RbI1NgaVTg6AeXBVbknA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-1.4.1.tgz",
+            "integrity": "sha512-0x7pWfLZpZsgtyotXtuepJc0rZYE0Aw8PwNAXs0jSG9zq6Sl5xmbWnFqfmRY01ieZLHNbvneSFm9/x88CvzAuw==",
             "dev": true,
             "requires": {
-                "defu": "^6.1.0",
-                "dotenv": "^16.0.2",
-                "gittar": "^0.1.1",
-                "jiti": "^1.15.0",
-                "mlly": "^0.5.14",
-                "pathe": "^0.3.8",
-                "pkg-types": "^0.3.5",
-                "rc9": "^1.2.2"
+                "chokidar": "^3.5.3",
+                "defu": "^6.1.2",
+                "dotenv": "^16.0.3",
+                "giget": "^1.1.2",
+                "jiti": "^1.18.2",
+                "mlly": "^1.2.0",
+                "ohash": "^1.1.1",
+                "pathe": "^1.1.0",
+                "perfect-debounce": "^0.1.3",
+                "pkg-types": "^1.0.2",
+                "rc9": "^2.1.0"
             }
         },
         "callsites": {
@@ -1478,10 +1488,26 @@
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true
         },
+        "chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            }
+        },
         "chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
             "dev": true
         },
         "ci-info": {
@@ -1532,6 +1558,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
         "combined-stream": {
@@ -1637,9 +1669,9 @@
             "dev": true
         },
         "defu": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.0.tgz",
-            "integrity": "sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+            "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
             "dev": true
         },
         "delayed-stream": {
@@ -1654,9 +1686,9 @@
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "destr": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/destr/-/destr-1.1.1.tgz",
-            "integrity": "sha512-QqkneF8LrYmwATMdnuD2MLI3GHQIcBnG6qFC2q9bSH430VTCDAVjcspPmUaKhPGtAtPAftIUFqY1obQYQuwmbg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+            "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
             "dev": true
         },
         "detect-newline": {
@@ -1883,7 +1915,8 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz",
             "integrity": "sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-prettier": {
             "version": "3.3.1",
@@ -1898,7 +1931,8 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
             "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -2182,12 +2216,23 @@
             }
         },
         "fs-minipass": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
             "dev": true,
             "requires": {
-                "minipass": "^2.6.0"
+                "minipass": "^3.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                }
             }
         },
         "fs.realpath": {
@@ -2239,14 +2284,19 @@
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true
         },
-        "gittar": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/gittar/-/gittar-0.1.1.tgz",
-            "integrity": "sha512-p+XuqWJpW9ahUuNTptqeFjudFq31o6Jd+maMBarkMAR5U3K9c7zJB4sQ4BV8mIqrTOV29TtqikDhnZfCD4XNfQ==",
+        "giget": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-1.1.2.tgz",
+            "integrity": "sha512-HsLoS07HiQ5oqvObOI+Qb2tyZH4Gj5nYGfF9qQcZNrPw+uEFhdXtgJr01aO2pWadGHucajYDLxxbtQkm97ON2A==",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1",
-                "tar": "^4.4.1"
+                "colorette": "^2.0.19",
+                "defu": "^6.1.2",
+                "https-proxy-agent": "^5.0.1",
+                "mri": "^1.2.0",
+                "node-fetch-native": "^1.0.2",
+                "pathe": "^1.1.0",
+                "tar": "^6.1.13"
             }
         },
         "glob": {
@@ -2339,9 +2389,9 @@
             }
         },
         "https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "requires": {
                 "agent-base": "6",
@@ -2418,6 +2468,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
         },
         "is-core-module": {
             "version": "2.6.0",
@@ -2815,7 +2874,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "27.4.0",
@@ -3032,9 +3092,9 @@
             }
         },
         "jiti": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.16.0.tgz",
-            "integrity": "sha512-L3BJStEf5NAqNuzrpfbN71dp43mYIcBUlCRea/vdyv5dW/AYa1d4bpelko4SHdY3I6eN9Wzyasxirj1/vv5kmg==",
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+            "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
             "dev": true
         },
         "js-tokens": {
@@ -3267,59 +3327,56 @@
                 "brace-expansion": "^1.1.7"
             }
         },
-        "minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+        "minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true
         },
-        "minipass": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
             },
             "dependencies": {
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
                 }
             }
         },
-        "minizlib": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-            "dev": true,
-            "requires": {
-                "minipass": "^2.9.0"
-            }
-        },
         "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.6"
-            }
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true
         },
         "mlly": {
-            "version": "0.5.16",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-0.5.16.tgz",
-            "integrity": "sha512-LaJ8yuh4v0zEmge/g3c7jjFlhoCPfQn6RCjXgm9A0Qiuochq4BcuOxVfWmdnCoLTlg2MV+hqhOek+W2OhG0Lwg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
+            "integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
             "dev": true,
             "requires": {
-                "acorn": "^8.8.0",
-                "pathe": "^0.3.8",
-                "pkg-types": "^0.3.5",
-                "ufo": "^0.8.5"
+                "acorn": "^8.8.2",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.2",
+                "ufo": "^1.1.1"
             }
+        },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true
         },
         "ms": {
             "version": "2.1.2",
@@ -3373,6 +3430,12 @@
                 }
             }
         },
+        "node-fetch-native": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+            "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+            "dev": true
+        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3410,6 +3473,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
+        },
+        "ohash": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.2.tgz",
+            "integrity": "sha512-9CIOSq5945rI045GFtcO3uudyOkYVY1nyfFxVQp+9BRgslr8jPNiSSrsFGg/BNTUFOLqx0P5tng6G32brIPw0w==",
             "dev": true
         },
         "once": {
@@ -3524,9 +3593,15 @@
             "dev": true
         },
         "pathe": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.9.tgz",
-            "integrity": "sha512-6Y6s0vT112P3jD8dGfuS6r+lpa0qqNrLyHPOwvXMnyNTQaYiwgau2DP3aNDsR13xqtGj7rrPo+jFUATpU6/s+g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
+            "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+            "dev": true
+        },
+        "perfect-debounce": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-0.1.3.tgz",
+            "integrity": "sha512-NOT9AcKiDGpnV/HBhI22Str++XWcErO/bALvHCuhv33owZW/CjH8KAFLZDCmu3727sihe0wTxpDhyGc6M8qacQ==",
             "dev": true
         },
         "picomatch": {
@@ -3553,14 +3628,14 @@
             }
         },
         "pkg-types": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-0.3.5.tgz",
-            "integrity": "sha512-VkxCBFVgQhNHYk9subx+HOhZ4jzynH11ah63LZsprTKwPCWG9pfWBlkElWFbvkP9BVR0dP1jS9xPdhaHQNK74Q==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+            "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
             "dev": true,
             "requires": {
                 "jsonc-parser": "^3.2.0",
-                "mlly": "^0.5.14",
-                "pathe": "^0.3.7"
+                "mlly": "^1.2.0",
+                "pathe": "^1.1.0"
             }
         },
         "prelude-ls": {
@@ -3638,14 +3713,14 @@
             "dev": true
         },
         "rc9": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-1.2.2.tgz",
-            "integrity": "sha512-zbe8+HR2X28eZepAwohuKkebbEsA67h0DO9I7g12QrHa2CQopR9gztOLPIPXXGTvcxeUjAN4wZ+b29t3m/u05g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.0.tgz",
+            "integrity": "sha512-ROO9bv8PPqngWKoiUZU3JDQ4sugpdRs9DfwHnzDSxK25XtQn6BEHL6EOd/OtKuDT2qodrtNR+0WkPT6l0jxH5Q==",
             "dev": true,
             "requires": {
-                "defu": "^6.0.0",
-                "destr": "^1.1.1",
-                "flat": "^5.0.0"
+                "defu": "^6.1.2",
+                "destr": "^1.2.2",
+                "flat": "^5.0.2"
             }
         },
         "react-is": {
@@ -3653,6 +3728,15 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
+        },
+        "readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
         },
         "regenerator-runtime": {
             "version": "0.13.7",
@@ -3943,32 +4027,17 @@
             }
         },
         "tar": {
-            "version": "4.4.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-            "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+            "version": "6.1.14",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.14.tgz",
+            "integrity": "sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==",
             "dev": true,
             "requires": {
-                "chownr": "^1.1.4",
-                "fs-minipass": "^1.2.7",
-                "minipass": "^2.9.0",
-                "minizlib": "^1.3.3",
-                "mkdirp": "^0.5.5",
-                "safe-buffer": "^5.2.1",
-                "yallist": "^3.1.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
-                }
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
             }
         },
         "terminal-link": {
@@ -4130,9 +4199,9 @@
             "dev": true
         },
         "ufo": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.5.tgz",
-            "integrity": "sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+            "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
             "dev": true
         },
         "universal-user-agent": {
@@ -4290,7 +4359,8 @@
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
             "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^4.12.0",
         "@typescript-eslint/parser": "^4.12.0",
-        "c12": "^0.2.13",
+        "c12": "^1.4.1",
         "esbuild": "^0.12.24",
         "eslint": "^7.17.0",
         "eslint-config-prettier": "^7.1.0",

--- a/src/utils/parseJestConfig.ts
+++ b/src/utils/parseJestConfig.ts
@@ -3,10 +3,18 @@ import { loadConfig } from 'c12';
 export const parseJestConfig = async (
     workingDirectory: string
 ): Promise<unknown> => {
-    const { config } = await loadConfig({
+    let { config } = await loadConfig({
         cwd: workingDirectory,
         name: 'jest',
     });
+
+    if (!config || Object.keys(config).length === 0) {
+        config = await loadConfig({
+            cwd: workingDirectory,
+            name: 'jest',
+            packageJson: true,
+        });
+    }
 
     return config;
 };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR fixes #228

Hi! Thank you for your work on this action! Looks very helpful. I just need to add config loading from package.json before I'll be able to use it in my projects.

It looks like the lib `c12` that was used for config loading, has already added such a possibility. Flag `packageJson` should load config from `package.json` section with name taken from `name` property. In our case just from `jest` block of package json.

https://github.com/unjs/c12/issues/29 Here is the feature in `c12` project

Looks like it appeared first in version `1.2.0`, but the newer the better 😅 So let it be 1.4.1.
