### PR TITLE
Allow checkout branch from private fork

### DIFF
--- a/src/stages/switchBranch.ts
+++ b/src/stages/switchBranch.ts
@@ -64,7 +64,11 @@ export const checkoutRef = async (
         } catch (err) {
             console.warn('Error fetching git repository', err);
         }
-        await exec(`git checkout ${ref.ref} -f`);
+        try {
+            await exec(`git checkout ${ref.ref} -f`);
+        } catch {
+            await exec(`git checkout ${ref.sha} -f`);
+        }
     }
 };
 

--- a/tests/stages/switchBranch.test.ts
+++ b/tests/stages/switchBranch.test.ts
@@ -114,6 +114,23 @@ describe('checkoutRef', () => {
 
         expect(exec).toBeCalledWith('git checkout hello -f');
     });
+    
+    it('should try git checkout by sha if ref fails', async () => {
+        (exec as jest.Mock<any, any>).mockImplementation((command) => {
+            if (command === 'git checkout hello -f') throw 0;
+        });
+
+        await checkoutRef(
+            {
+                ref: 'hello',
+                sha: '123456',
+            } as GithubRef,
+            'remote-1',
+            'branch-1'
+        );
+
+        expect(exec).toHaveBeenNthCalledWith(3, 'git checkout 123456 -f');
+    });
 });
 
 describe('getCurrentBranch', () => {

--- a/tests/stages/switchBranch.test.ts
+++ b/tests/stages/switchBranch.test.ts
@@ -114,7 +114,7 @@ describe('checkoutRef', () => {
 
         expect(exec).toBeCalledWith('git checkout hello -f');
     });
-    
+
     it('should try git checkout by sha if ref fails', async () => {
         (exec as jest.Mock<any, any>).mockImplementation((command) => {
             if (command === 'git checkout hello -f') throw 0;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR fixes #393.

If `git checkout` by `ref.ref` fails, try `git checkout` by `ref.sha` since the PR head commit is available in the base repo.

This can be tested by creating a private repo with the github action, making a fork, and making a PR from the fork.

I've added an unit test accordingly.

