### PR TITLE
Accessible icon set

### DIFF
--- a/src/format/strings.json
+++ b/src/format/strings.json
@@ -13,6 +13,19 @@
             "receipt": "🧾",
             "grey_question": "❔"
         },
+        "accessible": {
+            "x": "❌",
+            "arrow_up_small": "🔺",
+            "small_red_triangle_down": "🔻",
+            "green_circle": "✅",
+            "yellow_circle": "⚠️",
+            "red_circle": "❎",
+            "hatching_chick": "🐣",
+            "joystick": "🕹️",
+            "herb": "🌿",
+            "receipt": "🧾",
+            "grey_question": "❔"
+        },
         "ascii": {
             "x": "[ !!! ]",
             "arrow_up_small": "",


### PR DESCRIPTION
Adds the 'accessible' format, which replaces the "stoplight" colored circles, which may be unclear to colorblind users, with distinct icons, and replaces the up arrow, which uses a different visual language and may be described differently on screen readers, with one that stylistically matches the down arrow.