### PR TITLE
feat: Add option to disable `onlyChanged` filter on coverage annotations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
     prnumber:
         required: false
         description: Pull Request number for this commit. Use if your action is running in a PR, but non on the pull_request event, so that you do not get multiple comments.
+    only-changed-files:
+        description: 'Only annotate changed files for coverage annotation in the current PR. (default: true)'
+        default: 'true'
     output:
         required: false
         description: What output should action produce? `comment` - add comment to PR, `report-markdown` - report markdown text in "outputs.report".

--- a/package-lock.json
+++ b/package-lock.json
@@ -2969,6 +2969,21 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/src/run.ts
+++ b/src/run.ts
@@ -216,7 +216,7 @@ export const run = async (
         }
 
         const octokit = getOctokit(options.token);
-        if (options.pullRequest?.number) {
+        if (options.pullRequest?.number && options.onlyChanged) {
             const patch = await getPrPatch(octokit, options);
             coverageAnnotations = onlyChanged(coverageAnnotations, patch);
         }

--- a/src/typings/Options.ts
+++ b/src/typings/Options.ts
@@ -40,6 +40,7 @@ export type Options = {
     baseCoverageFile?: string;
     prNumber: null | number;
     pullRequest: null | PullRequest;
+    onlyChanged: boolean;
     output: Array<OutputType>;
 };
 
@@ -84,6 +85,7 @@ const optionSchema = yup.object().shape({
     baseCoverageFile: yup.string(),
     prNumber: yup.number().nullable(),
     pullRequest: yup.object().nullable(),
+    onlyChanged: yup.boolean().default(true),
     output: yup
         .array()
         .required()
@@ -115,6 +117,7 @@ export const getOptions = async (): Promise<Options> => {
     const prNumber: number | null = Number(
         getInput('prnumber') || context?.payload?.pull_request?.number
     );
+    const onlyChanged = getInput('only-changed-files') || true;
     const output = getInput('output');
     let pullRequest = context?.payload?.pull_request || null;
 
@@ -141,6 +144,7 @@ export const getOptions = async (): Promise<Options> => {
             baseCoverageFile,
             prNumber: prNumber || null,
             pullRequest,
+            onlyChanged,
             output,
         })) as Options;
 

--- a/tests/format/annotations/formatCoverageAnnotations.test.ts
+++ b/tests/format/annotations/formatCoverageAnnotations.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_OPTIONS: Options = {
             repo: { clone_url: 'https://github.com/test/repo.git' },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/format/annotations/formatFailedTestsAnnotations.test.ts
+++ b/tests/format/annotations/formatFailedTestsAnnotations.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_OPTIONS: Options = {
             repo: { clone_url: 'https://github.com/test/repo.git' },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/report/fetchPreviousReport.test.ts
+++ b/tests/report/fetchPreviousReport.test.ts
@@ -25,6 +25,7 @@ const DEFAULT_OPTIONS: Options = {
             repo: { clone_url: 'https://github.com/test/repo.git' },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/report/generatePRReport.test.ts
+++ b/tests/report/generatePRReport.test.ts
@@ -25,6 +25,7 @@ const DEFAULT_OPTIONS: Options = {
             repo: { clone_url: 'https://github.com/test/repo.git' },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -7,6 +7,7 @@ import { mocked } from 'ts-jest/utils';
 import { Annotation } from '../src/annotations/Annotation';
 import { createCoverageAnnotations } from '../src/annotations/createCoverageAnnotations';
 import { createFailedTestsAnnotations } from '../src/annotations/createFailedTestsAnnotations';
+import { onlyChanged } from '../src/filters/onlyChanged';
 import { formatCoverageAnnotations } from '../src/format/annotations/formatCoverageAnnotations';
 import { formatFailedTestsAnnotations } from '../src/format/annotations/formatFailedTestsAnnotations';
 import { run } from '../src/run';
@@ -209,6 +210,7 @@ const defaultOptions: Options = {
             },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 
@@ -220,6 +222,7 @@ jest.mock('../src/report/generatePRReport.ts');
 jest.mock('../src/report/generateCommitReport.ts');
 jest.mock('../src/annotations/createFailedTestsAnnotations.ts');
 jest.mock('../src/annotations/createCoverageAnnotations.ts');
+jest.mock('../src/filters/onlyChanged.ts');
 jest.mock('../src/format/annotations/formatFailedTestsAnnotations.ts');
 jest.mock('../src/format/annotations/formatCoverageAnnotations.ts');
 
@@ -429,6 +432,7 @@ describe('run', () => {
     describe('coverageAnnotations', () => {
         const createCoverageAnnotationsMock = mocked(createCoverageAnnotations);
         const formatCoverageAnnotationsMock = mocked(formatCoverageAnnotations);
+        const onlyChangedMock = mocked(onlyChanged);
 
         beforeEach(() => {
             createCoverageAnnotationsMock.mockClear();
@@ -442,6 +446,16 @@ describe('run', () => {
             });
             await run();
             expect(createCoverageAnnotationsMock).not.toBeCalled();
+        });
+
+        it('should not filter out annotations on unchanged files for current PR if disabled by options', async () => {
+            getOptionsMock.mockResolvedValue({
+                ...defaultOptions,
+                onlyChanged: false,
+            });
+            await run();
+            expect(createCoverageAnnotationsMock).toBeCalled();
+            expect(onlyChangedMock).not.toBeCalled();
         });
     });
 });

--- a/tests/stages/createReport.test.ts
+++ b/tests/stages/createReport.test.ts
@@ -30,6 +30,7 @@ const DEFAULT_OPTIONS: Options = {
             repo: { clone_url: 'https://github.com/test/repo.git' },
         },
     },
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/stages/getCoverage.test.ts
+++ b/tests/stages/getCoverage.test.ts
@@ -23,6 +23,7 @@ const defaultOptions: Options = {
     skipStep: 'none',
     prNumber: null,
     pullRequest: null,
+    onlyChanged: true,
     output: ['comment'],
 };
 

--- a/tests/typings/Options.test.ts
+++ b/tests/typings/Options.test.ts
@@ -75,6 +75,7 @@ const parsedOptions = {
     baseCoverageFile: 'base.json',
     prNumber: null,
     pullRequest: null,
+    onlyChanged: true,
     output: ['comment'],
 };
 
@@ -127,6 +128,14 @@ describe('getOptions', () => {
         clearInputMock();
 
         mockInput({ ...options, ['threshold']: 'asdf' });
+        await expect(getOptions()).resolves.toBeDefined();
+        clearInputMock();
+
+        mockInput({ ...options, ['only-changed-files']: 'nope' });
+        await expect(getOptions()).rejects.toBeDefined();
+        clearInputMock();
+
+        mockInput({ ...options, ['only-changed-files']: '' });
         await expect(getOptions()).resolves.toBeDefined();
         clearInputMock();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Code of Conduct: https://github.com/ArtiomTr/jest-coverage-report-action/blob/master/CODE_OF_CONDUCT.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
* Update tests as appropriate
-->

This PR maybe fixes #398 .

## Summary

- Adds a new `only-changed-files` input option to enable/disable filtering of the coverage annotations based on PR changes
- Default is `true` (backward compatible), which means it enables the filtering
- With this new feature it is now possible to always see annotations for uncovered lines on PR checks, regardless of what has changed in the PR

## Changes
- Add `only-changed-files` input to action.yml (default: true)
- Add `onlyChanged` to Options type with yup validation  
- Add another condition on `onlyChanged` to the filtering routine of the `coverageAnnotations` stage
- Update all test files with new `onlyChanged` field
- Add new tests to test input validation of the new option and to test that the `false` case correctly skips the call to `onlyChanged` method in the `coverageAnnotations` stage

## Usage
```yaml
- uses: ArtiomTr/jest-coverage-report-action@v2
  with:
    only-changed-files: 'false'  # Disable coverage annotations filtering
```

## Test plan
- [x] All existing tests pass
- [ ] Verify PR check annotations shows uncovered lines, regardless of PR changes
- [ ] Verify default doesn't annotate on lines that aren't included in the PR changes (backward compatible)